### PR TITLE
JS code that fails on JSCore - Bug 184267 - Exercise 1 - Gloria

### DIFF
--- a/seeds/exercise_1/jscore_184267.js
+++ b/seeds/exercise_1/jscore_184267.js
@@ -1,0 +1,8 @@
+//https://bugs.webkit.org/show_bug.cgi?id=184267
+
+const proxy = new Proxy([3, 4], {});
+const res = [1, 2].concat(proxy);
+
+if((res[3]===undefined)){
+    throw new Error('Test failed');
+}


### PR DESCRIPTION
Bug 184267 reported on https://bugs.webkit.org/show_bug.cgi?id=184267 that fails on JSCore.